### PR TITLE
#41 Migrate to Eclipse 2021-06

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent { label 'migration' }
   tools {
         maven 'apache-maven-latest'
-        jdk 'oracle-jdk8-latest'
+        jdk 'openjdk-jdk11-latest'
   }
   parameters {
     string(name: 'CORE_BRANCH', defaultValue: 'master', description: 'When build is not triggered by diffmerge-core build, set the branch of diffmerge-core')

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.core.gen.edit/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.core.gen.edit/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-Name: %pluginName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime,org.eclipse.emf.diffmerge.patterns.core,org.eclipse.emf.diffmerge.patterns.core.gen;visibility:=
  reexport,org.eclipse.emf.edit;visibility:=reexport,org.eclipse.emf.ec
  ore;visibility:=reexport,org.eclipse.emf.ecore.edit;visibility:=reexp

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.core.gen/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.core.gen/META-INF/MANIFEST.MF
@@ -14,6 +14,6 @@ Bundle-Name: %pluginName
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.emf.diffmerge.patterns.core.gen;sing
  leton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.emf.diffmerge.patterns.core.gen
 

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.core/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.core/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Export-Package: org.eclipse.emf.diffmerge.patterns.core;uses:="org.eclipse.osgi.
 Bundle-ActivationPolicy: lazy
 Bundle-Name: %pluginName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore,
  org.eclipse.emf.edit,

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.diagrams/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.diagrams/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.patterns.templates.engine,
  org.eclipse.emf.diffmerge.patterns.repositories.catalogs,
  org.eclipse.emf.diffmerge.patterns.core.gen.edit
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.diffmerge.patterns.diagrams,
  org.eclipse.emf.diffmerge.patterns.diagrams.extensions,

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.repositories.catalogs/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.repositories.catalogs/META-INF/MANIFEST.MF
@@ -21,6 +21,6 @@ Bundle-Name: %pluginName
 Bundle-Activator: org.eclipse.emf.diffmerge.patterns.repositories.catalogs.PatternCatalogsPlugin
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.emf.diffmerge.patterns.repositories.catalogs;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.emf.diffmerge.patterns.repositories.catalogs
 

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.support.gen.edit/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.support.gen.edit/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.diffmerge.patterns.support.gen.commonpatternsupport.provider.CommonPatternSupportEditPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.patterns.support.gen.commonpatternsupport.provider
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.patterns.support.gen;visibility:=reexport,

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.support.gen/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.support.gen/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.patterns.core.gen;visibility:=reexport,
  org.eclipse.emf.edit
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.patterns.support.gen,
  org.eclipse.emf.diffmerge.patterns.support.gen.commonpatternsupport,
  org.eclipse.emf.diffmerge.patterns.support.gen.commonpatternsupport.impl,

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.support/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.support/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore.xmi,
  org.eclipse.core.resources,
  org.eclipse.emf.transaction
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.diffmerge.patterns.support,
  org.eclipse.emf.diffmerge.patterns.support.contributions,

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.engine/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.engine/META-INF/MANIFEST.MF
@@ -28,6 +28,6 @@ Bundle-Activator: org.eclipse.emf.diffmerge.patterns.templates.engine
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.emf.diffmerge.patterns.templates.eng
  ine;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.emf.diffmerge.patterns.templates.engine
 

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.gen.edit/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.gen.edit/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.diffmerge.patterns.templates.gen.templatepatterns.provider.TemplatePatternsEditPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.patterns.templates.gen.templatepatterns.provider
 Require-Bundle: org.eclipse.core.runtime,org.eclipse.emf.diffmerge.patterns.templates.gen;visibility:=reexport,org.eclipse.emf.edit;visibi
  lity:=reexport,org.eclipse.emf.diffmerge.patterns.core.gen;visibilit

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.gen.editor/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.gen.editor/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.diffmerge.patterns.templates.gen.templatepatterns.presentation.TemplatePatternsEditorPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.diffmerge.patterns.templates.gen.templatepatterns.presentation
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;visibility:=reexport,

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.gen/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.gen/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Export-Package: org.eclipse.emf.diffmerge.patterns.templates.gen,org.eclipse.emf
 Bundle-ClassPath: .
 Bundle-Name: %pluginName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.diffmerge.patterns.core;visibility:=reexport,

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.ocl/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.templates.ocl/META-INF/MANIFEST.MF
@@ -14,6 +14,6 @@ Bundle-Name: %pluginName
 Bundle-Activator: org.eclipse.emf.diffmerge.patterns.templates.ocl.OclPatternsPlugin
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.emf.diffmerge.patterns.templates.ocl;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.emf.diffmerge.patterns.templates.ocl
 

--- a/core/plugins/org.eclipse.emf.diffmerge.patterns.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.eclipse.emf.diffmerge.patterns.ui/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.gmf.runtime.diagram.ui,
  org.eclipse.emf.ecore.editor,
  org.eclipse.emf.diffmerge.patterns.templates.gen.editor,
  org.eclipse.emf.ecore
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.diffmerge.patterns.ui,
  org.eclipse.emf.diffmerge.patterns.ui.actions,

--- a/releng/org.eclipse.emf.diffmerge.patterns.configuration/pom.xml
+++ b/releng/org.eclipse.emf.diffmerge.patterns.configuration/pom.xml
@@ -6,13 +6,13 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<cbi.jarsigner.version>1.1.3</cbi.jarsigner.version>
+		<cbi.jarsigner.version>1.3.2</cbi.jarsigner.version>
 		<core.repo.url>diffmerge/lastSuccessfulBuild/artifact/releng/org.eclipse.emf.diffmerge.update/target</core.repo.url>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho.version>1.7.0</tycho.version>
+		<tycho.version>2.0.0</tycho.version>
 		<tycho.extras.version>${tycho.version}</tycho.extras.version>
 	</properties>
 
@@ -41,6 +41,7 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
+					<executionEnvironment>JavaSE-11</executionEnvironment>
 					<target>
 						<artifact>
 							<groupId>org.eclipse.emf.diffmerge</groupId>
@@ -114,19 +115,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200a-plugin</artifactId>
-						<version>${tycho.version}</version>
-						<executions>
-							<execution>
-								<id>pack200-normalize</id>
-								<goals>
-									<goal>normalize</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
 						<version>${cbi.jarsigner.version}</version>
@@ -137,19 +125,6 @@
 									<goal>sign</goal>
 								</goals>
 								<phase>verify</phase>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200b-plugin</artifactId>
-						<version>${tycho.version}</version>
-						<executions>
-							<execution>
-								<id>pack200-pack</id>
-								<goals>
-									<goal>pack</goal>
-								</goals>
 							</execution>
 						</executions>
 					</plugin>

--- a/releng/org.eclipse.emf.diffmerge.patterns.configuration/toolchains-hipp.xml
+++ b/releng/org.eclipse.emf.diffmerge.patterns.configuration/toolchains-hipp.xml
@@ -2,6 +2,15 @@
   <toolchain>
     <type>jdk</type>
     <provides>
+      <id>JavaSE-11</id>
+    </provides>
+    <configuration>
+      <jdkHome>/opt/tools/java/openjdk/jdk-11/latest</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
       <id>JavaSE-1.8</id>
     </provides>
     <configuration>

--- a/releng/org.eclipse.emf.diffmerge.patterns.javadoc/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.emf.diffmerge.patterns.javadoc/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Javadoc for Diff/Merge Core (Incubation)
 Bundle-SymbolicName: org.eclipse.emf.diffmerge.patterns.javadoc
 Bundle-Version: 0.14.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.emf.diffmerge.patterns.javadoc

--- a/releng/org.eclipse.emf.diffmerge.patterns.target/org.eclipse.emf.diffmerge.patterns.target.target
+++ b/releng/org.eclipse.emf.diffmerge.patterns.target/org.eclipse.emf.diffmerge.patterns.target.target
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="org.eclipse.emf.diffmerge.patterns" sequenceNumber="1581955536">
+<target name="org.eclipse.emf.diffmerge.patterns" sequenceNumber="1628778446">
   <locations>
-    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
       <repository location="http://download.eclipse.org/cbi/updates/license/"/>
     </location>
-    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
       <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.26.0.v20210506-1425"/>
       <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.validation.sdk.feature.group" version="0.0.0"/>
@@ -26,14 +26,16 @@
       <unit id="org.eclipse.ocl.all.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ocl.examples.feature.group" version="0.0.0"/>
       <unit id="com.google.guava" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/releases/2020-06"/>
+      <repository location="http://download.eclipse.org/releases/2021-06"/>
     </location>
-    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sirius.runtime.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.sirius.specifier.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.sirius.specifier.ide.ui.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/sirius/updates/releases/6.4.0/2020-06"/>
+      <repository location="https://download.eclipse.org/sirius/updates/stable/7.0.0-S20210722-123507/2021-06"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.apache.batik.bridge.source" version="0.0.0"/>
+      <repository id="Orbit" location="https://download.eclipse.org/tools/orbit/downloads/2021-06"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.emf.diffmerge.patterns.target/org.eclipse.emf.diffmerge.patterns.target.tpd
+++ b/releng/org.eclipse.emf.diffmerge.patterns.target/org.eclipse.emf.diffmerge.patterns.target.tpd
@@ -1,10 +1,12 @@
 target "org.eclipse.emf.diffmerge.patterns"
 
+with source, requirements
+
 location "http://download.eclipse.org/cbi/updates/license/" {
-	org.eclipse.license.feature.group [2.0.2.v20181016-2210,2.0.2.v20181016-2210]
+	org.eclipse.license.feature.group lazy
 }
 
-location "http://download.eclipse.org/releases/2020-06" {
+location "http://download.eclipse.org/releases/2021-06" {
 	org.eclipse.equinox.executable.feature.group lazy
 	org.eclipse.platform.sdk lazy
   	org.eclipse.jdt.feature.group lazy
@@ -25,9 +27,11 @@ location "http://download.eclipse.org/releases/2020-06" {
 	com.google.guava lazy
 }
 
-location "https://download.eclipse.org/sirius/updates/stable/6.4.0-S20200921-043506/2020-06" {
+location "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20210722-123507/2021-06" {
 	org.eclipse.sirius.runtime.feature.group lazy
 	org.eclipse.sirius.runtime.ide.ui.feature.group lazy
-	org.eclipse.sirius.specifier.feature.group lazy
-	org.eclipse.sirius.specifier.ide.ui.feature.group lazy
+}
+
+location Orbit "https://download.eclipse.org/tools/orbit/downloads/2021-06" {
+	org.apache.batik.bridge.source lazy
 }

--- a/sirius/plugins/org.eclipse.emf.diffmerge.patterns.diagrams.sirius/META-INF/MANIFEST.MF
+++ b/sirius/plugins/org.eclipse.emf.diffmerge.patterns.diagrams.sirius/META-INF/MANIFEST.MF
@@ -12,13 +12,13 @@ Require-Bundle: org.eclipse.emf.diffmerge,
  org.eclipse.emf.diffmerge.patterns.support,
  org.eclipse.gmf.runtime.diagram.ui.render,
  org.eclipse.gmf.runtime.notation,
- org.eclipse.sirius;bundle-version="6.2.0",
- org.eclipse.sirius.diagram;bundle-version="6.2.0",
- org.eclipse.sirius.ecore.extender;bundle-version="6.2.0",
- org.eclipse.sirius.common;bundle-version="6.2.0",
- org.eclipse.sirius.diagram.ui;bundle-version="6.2.0"
+ org.eclipse.sirius,
+ org.eclipse.sirius.diagram,
+ org.eclipse.sirius.ecore.extender,
+ org.eclipse.sirius.common,
+ org.eclipse.sirius.diagram.ui
 Comment:  fr.obeo.dsl.viewpoint, fr.obeo.dsl.viewpoint.diagram, fr.obeo.mda.ecore.extender
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.diffmerge.patterns.diagrams.sirius,
  org.eclipse.emf.diffmerge.patterns.diagrams.sirius.extensions,

--- a/sirius/plugins/org.eclipse.emf.diffmerge.patterns.ui.sirius/META-INF/MANIFEST.MF
+++ b/sirius/plugins/org.eclipse.emf.diffmerge.patterns.ui.sirius/META-INF/MANIFEST.MF
@@ -13,12 +13,12 @@ Require-Bundle: org.eclipse.emf.diffmerge.patterns.templates.engine,
  org.eclipse.emf.diffmerge.patterns.ui,
  org.eclipse.emf.diffmerge.patterns.diagrams.sirius,
  org.eclipse.emf.diffmerge.patterns.diagrams,
- org.eclipse.sirius.diagram.sequence;bundle-version="6.0.0",
- org.eclipse.sirius.diagram.ui;bundle-version="6.0.0",
- org.eclipse.sirius.diagram;bundle-version="6.0.0",
+ org.eclipse.sirius.diagram.sequence,
+ org.eclipse.sirius.diagram.ui,
+ org.eclipse.sirius.diagram,
  org.eclipse.ui.ide
 Comment: fr.obeo.dsl.viewpoint.diagram.sequence
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.diffmerge.patterns.ui.sirius,
  org.eclipse.emf.diffmerge.patterns.ui.sirius.dialogs,


### PR DESCRIPTION
- Update TP
  - Eclipse 2021-06
  - Sirius 7.0.0 stable
  - Add batik bridge and script dependencies necessary for Sirius
- Tycho 2.0.0
- Explicit Java 11 (toolchains and MANIFESTs)
- Remove use of pack200
- Update eclipse-jarsigner-plugin to 1.3.2 (see #42)
- Remove explicit version dependency for patterns.*.sirius plugins

- Impact of software dependencies modifications: Sirius API changes

Change-Id: I0c975a4d7fe2a83a193257094266ff31b7ce93d1